### PR TITLE
Enable CI builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,27 @@
+name: "FAP: Build and lint"
+on: [push, pull_request]
+jobs:
+  ufbt-build-action:
+    runs-on: ubuntu-latest
+    name: 'ufbt: Build for Dev branch'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Build with ufbt
+        uses: flipperdevices/flipperzero-ufbt-action@v0.1.2
+        id: build-app
+        with:
+          # Set to 'release' to build for latest published release version
+          sdk-channel: release
+      - name: Upload app artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ github.event.repository.name }}-${{ steps.build-app.outputs.suffix }}
+          path: ${{ steps.build-app.outputs.fap-artifacts }}
+      # You can remove this step if you don't want to check source code formatting
+      - name: Lint sources
+        uses: flipperdevices/flipperzero-ufbt-action@v0.1.2
+        with:
+          # skip SDK setup, we already did it in previous step
+          skip-setup: true
+          task: lint

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,25 +3,34 @@ on: [push, pull_request]
 jobs:
   ufbt-build-action:
     runs-on: ubuntu-latest
-    name: 'ufbt: Build for Dev branch'
+    name: 'ufbt: Build for Release branch'
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Setup ufbt
+        uses: flipperdevices/flipperzero-ufbt-action@v0.1.2
+        with:
+          task: setup
+          sdk-channel: release
+
       - name: Build with ufbt
         uses: flipperdevices/flipperzero-ufbt-action@v0.1.2
         id: build-app
         with:
-          # Set to 'release' to build for latest published release version
+          skip-setup: true
           sdk-channel: release
+
       - name: Upload app artifacts
         uses: actions/upload-artifact@v3
         with:
           name: ${{ github.event.repository.name }}-${{ steps.build-app.outputs.suffix }}
           path: ${{ steps.build-app.outputs.fap-artifacts }}
-      # You can remove this step if you don't want to check source code formatting
-      - name: Lint sources
-        uses: flipperdevices/flipperzero-ufbt-action@v0.1.2
-        with:
-          # skip SDK setup, we already did it in previous step
-          skip-setup: true
-          task: lint
+
+      # # You can remove this step if you don't want to check source code formatting
+      # - name: Lint sources
+      #   uses: flipperdevices/flipperzero-ufbt-action@v0.1.2
+      #   with:
+      #     # skip SDK setup, we already did it in previous step
+      #     skip-setup: true
+      #     task: lint

--- a/application.fam
+++ b/application.fam
@@ -1,7 +1,7 @@
 App(
     appid="passgen",
     name="Password Generator",
-    apptype=FlipperAppType.PLUGIN,
+    apptype=FlipperAppType.EXTERNAL,
     entry_point="passgenapp",
     requires=[
         "gui",

--- a/passgen.c
+++ b/passgen.c
@@ -27,6 +27,25 @@ typedef enum PassGen_Alphabet
 	Mixed = DigitsAllLetters | Special
 } PassGen_Alphabet;
 
+const char * const PassGen_AlphabetChars [16] = {
+	"0", // invalid value
+	/*    PASSGEN_SPECIAL    PASSGEN_LETTERS_UP    PASSGEN_LETTERS_LOW */ PASSGEN_DIGITS   ,
+	/*    PASSGEN_SPECIAL    PASSGEN_LETTERS_UP */ PASSGEN_LETTERS_LOW /* PASSGEN_DIGITS */,
+	/*    PASSGEN_SPECIAL    PASSGEN_LETTERS_UP */ PASSGEN_LETTERS_LOW    PASSGEN_DIGITS   ,
+	/*    PASSGEN_SPECIAL */ PASSGEN_LETTERS_UP /* PASSGEN_LETTERS_LOW    PASSGEN_DIGITS */,
+	/*    PASSGEN_SPECIAL */ PASSGEN_LETTERS_UP /* PASSGEN_LETTERS_LOW */ PASSGEN_DIGITS   ,
+	/*    PASSGEN_SPECIAL */ PASSGEN_LETTERS_UP    PASSGEN_LETTERS_LOW /* PASSGEN_DIGITS */,
+	/*    PASSGEN_SPECIAL */ PASSGEN_LETTERS_UP    PASSGEN_LETTERS_LOW    PASSGEN_DIGITS   ,
+	      PASSGEN_SPECIAL /* PASSGEN_LETTERS_UP    PASSGEN_LETTERS_LOW    PASSGEN_DIGITS */,
+	      PASSGEN_SPECIAL /* PASSGEN_LETTERS_UP    PASSGEN_LETTERS_LOW */ PASSGEN_DIGITS   ,
+	      PASSGEN_SPECIAL /* PASSGEN_LETTERS_UP */ PASSGEN_LETTERS_LOW /* PASSGEN_DIGITS */,
+	      PASSGEN_SPECIAL /* PASSGEN_LETTERS_UP */ PASSGEN_LETTERS_LOW    PASSGEN_DIGITS   ,
+	      PASSGEN_SPECIAL    PASSGEN_LETTERS_UP /* PASSGEN_LETTERS_LOW    PASSGEN_DIGITS */,
+	      PASSGEN_SPECIAL    PASSGEN_LETTERS_UP /* PASSGEN_LETTERS_LOW */ PASSGEN_DIGITS   ,
+	      PASSGEN_SPECIAL    PASSGEN_LETTERS_UP    PASSGEN_LETTERS_LOW /* PASSGEN_DIGITS */,
+	      PASSGEN_SPECIAL    PASSGEN_LETTERS_UP    PASSGEN_LETTERS_LOW    PASSGEN_DIGITS   ,
+};
+
 const int AlphabetLevels[] = { Digits, Lowercase, DigitsLower, DigitsAllLetters, Mixed };
 const char* AlphabetLevelNames[] = { "1234", "abcd", "ab12", "Ab12", "Ab1#" };
 const int AlphabetLevelsCount = sizeof(AlphabetLevels) / sizeof(int);
@@ -45,8 +64,8 @@ typedef struct {
     Gui* gui;
     FuriMutex** mutex;
 	NotificationApp* notify;
+	const char* alphabet;
 	char password[PASSGEN_MAX_LENGTH+1];
-	char alphabet[PASSGEN_CHARACTERS_LENGTH+1];
 	int length;
 	int level;
 } PassGen;
@@ -100,15 +119,11 @@ static void render_callback(Canvas* canvas, void* ctx) {
 void build_alphabet(PassGen* app)
 {
 	PassGen_Alphabet mode = AlphabetLevels[app->level];
-	app->alphabet[0] = '\0';
-	if ((mode & Digits) != 0)
-		strcat(app->alphabet, PASSGEN_DIGITS);
-	if ((mode & Lowercase) != 0)
-		strcat(app->alphabet, PASSGEN_LETTERS_LOW);
-	if ((mode & Uppercase) != 0)
-		strcat(app->alphabet, PASSGEN_LETTERS_UP);
-	if ((mode & Special) != 0)
-		strcat(app->alphabet, PASSGEN_SPECIAL);
+	if (mode > 0 && mode < 16) {
+		app->alphabet = PassGen_AlphabetChars[mode];
+	} else {
+		app->alphabet = PassGen_AlphabetChars[0]; // Invalid mode ... password will be all zero digits
+	}
 }
 
 PassGen* state_init() {


### PR DESCRIPTION
I've installed and run the .FAP from this branch.


This PR enables the official [`ufbt`](https://github.com/marketplace/actions/build-flipper-application-package-fap) github action to automatically build the application on `push` and `pull_request`.

To get this working cleanly:

1. Fixed manifest to list correct apptype (External == FAP, since this is not internal firmware plugin) -- identical fix to #3.
2. Fixed manifest to have terminating newline.
3. Fix build warning from using strcat
<details><summary>Details</summary><p/>

Flipper Zero **_intentionally_** does not expose this function, and `ufbt` warns that the application may not run as a result.  `strcat` is only used to concatenate all the selected character sets.

As there's only 16 possible settings (digits, lowercase, uppercase, special chars), I just defined these (as `const` array of pointers to `const char*` ... so should be FLASH friendly).

</details><HR/>
